### PR TITLE
Switch to fileutils for Ruby 1.9+

### DIFF
--- a/lib/mite_cmd/application.rb
+++ b/lib/mite_cmd/application.rb
@@ -1,4 +1,8 @@
-require 'ftools'
+if RUBY_VERSION >= '1.9'
+  require 'fileutils'
+else
+  require 'ftools'
+end
 
 module MiteCmd
   class Application


### PR DESCRIPTION
If we are running on Ruby 1.9 use fileutils instead of ftools(which is now deprecated)